### PR TITLE
initial support for vlc tested under ubuntu linux 12.14 for unreal engin...

### DIFF
--- a/Source/VlcMedia/Private/Player/VlcMediaPlayer.cpp
+++ b/Source/VlcMedia/Private/Player/VlcMediaPlayer.cpp
@@ -399,7 +399,7 @@ FVlcMediaPlayer::FVlcMediaPlayer()
 #endif
 
 	char const *vlc_argv[] = {
-		"--verbose=2",
+//		"--verbose=2",
 		"--no-video-title-show",
 		"--no-stats",
 		"--no-sub-autodetect-file",
@@ -408,12 +408,11 @@ FVlcMediaPlayer::FVlcMediaPlayer()
 		"--no-snapshot-preview",
 //		"--intf", "dummy",
 	//	"--vout", "dummy",
-		"--no-audio", /* skip any audio track */
+//		"--no-audio", /* skip any audio track */
 		"--no-xlib", /* tell VLC to not use Xlib */
 	};
 	int vlc_argc = sizeof(vlc_argv) / sizeof(*vlc_argv);
 	vlchandle = libvlc_new(vlc_argc, vlc_argv);
-	printf("vlc setup done\n");
 }
 
 FVlcMediaPlayer::~FVlcMediaPlayer()
@@ -478,7 +477,6 @@ void FVlcMediaPlayer::Close()
 	libvlc_media_player_stop((libvlc_media_player_t*)vlcmedia);
 	libvlc_media_player_release((libvlc_media_player_t*)vlcmedia);
 	libvlc_release((libvlc_instance_t*)vlchandle);
-	printf("vlc close\n");
 	vlcmedia = 0;
 
 #ifdef VLCSDL

--- a/Source/VlcMedia/Private/Player/VlcMediaPlayer.cpp
+++ b/Source/VlcMedia/Private/Player/VlcMediaPlayer.cpp
@@ -1,18 +1,427 @@
 // Copyright 2015 Headcrash Industries LLC. All Rights Reserved.
+// modified by @anselm
 
 #include "VlcMediaPrivatePCH.h"
+
+#define LOCTEXT_NAMESPACE "FVlcMediaModule"
+
+// xxx TODO unsure exactly the right thing to do there
+#define VIDEOWIDTH 1280 
+#define VIDEOHEIGHT 720 
+
+///////////////////////////////////////////////////////////////////////////////////////////
+
+class FVlcMediaPlayer::MediaTrack
+        : public IMediaTrack
+{
+public:
+
+        MediaTrack(FVlcMediaPlayer & Player, int Index)
+                : MediaPlayer(Player)
+                , TrackIndex(Index)
+                , TrackIsEnabled(true)
+        {
+		printf("VLC:Media track started\n");
+        }
+
+        virtual void AddSink(const IMediaSinkRef& Sink)
+        {
+                Sinks.AddUnique(IMediaSinkWeakPtr(Sink));
+        }
+
+        virtual bool Disable()
+        {
+                TrackIsEnabled = false;
+                return MediaPlayer.MediaState != EMediaState::Error;
+        }
+
+        virtual bool Enable()
+        {
+                TrackIsEnabled = true;
+                return MediaPlayer.MediaState != EMediaState::Error;
+        }
+
+        virtual const IMediaTrackAudioDetails& GetAudioDetails() const
+        {
+                verify(false); // not an audio track
+                return *static_cast<IMediaTrackAudioDetails*>(nullptr);
+        }
+
+        virtual const IMediaTrackCaptionDetails& GetCaptionDetails() const
+        {
+                verify(false); // not a caption track
+                return *static_cast<IMediaTrackCaptionDetails*>(nullptr);
+        }
+
+        virtual FText GetDisplayName() const
+        {
+                return FText::Format(LOCTEXT("UnnamedTrackFormat", "Unnamed Track {0}"), FText::AsNumber(GetIndex()));
+        }
+
+        virtual uint32 GetIndex() const
+        {
+                return TrackIndex;
+        }
+
+        virtual FString GetLanguage() const
+        {
+                return TEXT("und");
+        }
+
+        virtual FString GetName() const
+        {
+                return FPaths::GetBaseFilename(MediaPlayer.MediaUrl);
+        }
+
+        virtual const IMediaTrackVideoDetails& GetVideoDetails() const
+        {
+                verify(false); // not a video track
+                return *static_cast<IMediaTrackVideoDetails*>(nullptr);
+        }
+
+        virtual bool IsEnabled() const
+        {
+                return TrackIsEnabled;
+        }
+
+        virtual bool IsMutuallyExclusive(const IMediaTrackRef& Other) const
+        {
+                return false;
+        }
+
+        virtual bool IsProtected() const
+        {
+                return false;
+        }
+
+        virtual void RemoveSink(const IMediaSinkRef& Sink)
+        {
+                Sinks.RemoveSingle(IMediaSinkWeakPtr(Sink));
+        }
+
+        virtual void Tick(float DeltaTime)
+        {
+        }
+
+        virtual bool TickInRenderThread()
+        {
+                return false;
+        }
+
+
+        virtual void ProcessMediaSample(void* SampleBuffer, uint32 SampleSize, FTimespan SampleDuration, FTimespan SampleTime)
+        {
+                for (IMediaSinkWeakPtr& SinkPtr : Sinks)
+                {
+                        IMediaSinkPtr Sink = SinkPtr.Pin();
+
+                        if (Sink.IsValid())
+                        {
+                                Sink->ProcessMediaSample(SampleBuffer, SampleSize, FTimespan(SampleDuration), FTimespan(SampleTime));
+                        }
+                }
+        }
+
+protected:
+
+        FVlcMediaPlayer & MediaPlayer;
+        int TrackIndex;
+        bool TrackIsEnabled;
+
+        // The collection of registered media sinks.
+        TArray<IMediaSinkWeakPtr> Sinks;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////////////////
+
+
+class FVlcMediaPlayer::VideoTrack
+	: public FVlcMediaPlayer::MediaTrack
+	, IMediaTrackVideoDetails
+{
+
+public:
+
+	VideoTrack(FVlcMediaPlayer & Player, int Index):
+		MediaTrack(Player,Index),
+		LastFramePosition(-1)
+	{
+		CurrentFramePosition = 0; // hack
+		printf("VLC:Media video started\n");
+	}
+
+	virtual bool Disable() {
+		return true;
+	}
+
+	virtual bool Enable() {
+		return true;
+	}
+
+	virtual EMediaTrackTypes GetType() const
+	{
+		return EMediaTrackTypes::Video;
+	}
+
+	virtual const IMediaTrackVideoDetails& GetVideoDetails() const
+	{
+		return *this;
+	}
+
+	virtual uint32 GetBitRate() const
+	{
+		return 0;
+	}
+
+	virtual FIntPoint GetDimensions() const
+	{
+		return FIntPoint(VIDEOWIDTH,VIDEOHEIGHT);
+	}
+
+	virtual float GetFrameRate() const
+	{
+		return 30.0f;
+	}
+
+	virtual void Tick(float DeltaTime) {
+		if(MediaPlayer.MediaState != EMediaState::Error)
+		{
+			CurrentFramePosition += DeltaTime * 1000;
+			if(LastFramePosition != CurrentFramePosition) {
+				LastFramePosition = CurrentFramePosition;
+				void* SampleData = 0;
+				int64 SampleCount = 0;
+				if(MediaPlayer.GetVideoLastFrameData(SampleData,SampleCount)) {
+					ProcessMediaSample(
+						SampleData, SampleCount,
+						FTimespan::MaxValue(),
+						FTimespan::FromMilliseconds(LastFramePosition));
+				}
+			}
+		}
+	}
+
+	virtual bool TickInRenderThread()
+	{
+		return true;
+	}
+
+private:
+
+	int32 LastFramePosition;
+	int32 CurrentFramePosition;
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////
+
+
+class FVlcMediaPlayer::AudioTrack
+        : public FVlcMediaPlayer::MediaTrack
+        , public IMediaTrackAudioDetails
+{
+public:
+
+        AudioTrack(FVlcMediaPlayer & Player, int Index)
+                : MediaTrack(Player, Index)
+        {
+        }
+
+        virtual bool Disable()
+        {
+                if (MediaTrack::Disable())
+                {
+                        //MediaPlayer.JavaMediaPlayer->SetAudioEnabled(false);
+                        return true;
+                }
+                return false;
+        }
+
+        virtual bool Enable()
+        {
+                if (MediaTrack::Enable())
+                {
+                        //MediaPlayer.JavaMediaPlayer->SetAudioEnabled(true);
+                        return true;
+                }
+                return false;
+        }
+
+        virtual const IMediaTrackAudioDetails& GetAudioDetails() const
+        {
+                return *this;
+        }
+
+        virtual EMediaTrackTypes GetType() const
+        {
+                return EMediaTrackTypes::Audio;
+        }
+
+        virtual uint32 GetNumChannels() const
+        {
+                return 1;
+        }
+
+        virtual uint32 GetSamplesPerSecond() const
+        {
+                return 0;
+        }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////
+
+#include <vlc/vlc.h>
+
+#ifdef VLCSDL
+
+#include <SDL/SDL.h>
+#include <SDL/SDL_mutex.h>
+
+struct VLCContext {
+  SDL_Surface* surf;
+  SDL_mutex* mutex;
+};
+
+static SDL_Surface* screen;
+static SDL_Event event;
+
+static void *vlc_lock(void *data, void **p_pixels)
+{
+    struct VLCContext *ctx = (struct VLCContext*) data;
+    SDL_LockMutex(ctx->mutex);
+    SDL_LockSurface(ctx->surf);
+    *p_pixels = ctx->surf->pixels;
+    return NULL;
+}
+
+static void vlc_unlock(void *data, void *id, void *const *p_pixels)
+{
+    struct VLCContext *ctx = (struct VLCContext *)data;
+
+    uint16_t *pixels = (uint16_t*)*p_pixels;
+    int x, y;
+
+    for(y = 10; y < 40; y++)
+        for(x = 10; x < 40; x++)
+            if(x < 13 || y < 13 || x > 36 || y > 36)
+                pixels[y * VIDEOWIDTH + x] = 0xffff;
+            else
+                pixels[y * VIDEOWIDTH + x] = 0x0;
+
+    SDL_UnlockSurface(ctx->surf);
+    SDL_UnlockMutex(ctx->mutex);
+}
+
+static void vlc_display(void *data, void *id) {
+    (void) data;
+}
+
+#else
+
+struct VLCContext {
+	void *pixeldata;
+	// std::mutex imagemutex;
+};
+
+static void* vlc_lock(void* data, void**p_pixels) {
+	struct VLCContext *ctx = (struct VLCContext*)data;
+	*p_pixels = ctx->pixeldata;
+	return NULL;
+}
+
+static void vlc_unlock(void* data, void* id, void *const *p_pixels) {
+}
+
+static void vlc_display(void* data, void* id) {
+	(void) data;
+}
+
+#endif
+
+bool FVlcMediaPlayer::GetVideoLastFrameData(void* &SampleData, int64 &SampleCount) {
+
+	if(!vlcmedia)return false;
+
+#ifdef VLCSDL
+	SDL_LockMutex(vlccontext->mutex);
+	// SDL_Rect rect = blah
+	// SDL_BlitSurface(vlccontext->surf,NULL,screen,&rect);
+	SDL_UnlockMutex(vlccontext->mutex);
+	// SDL_Flip(screen);
+	// SDL_Delay(10);
+#else
+
+    SampleData = vlccontext->pixeldata;
+    SampleCount = VIDEOWIDTH*VIDEOHEIGHT*4;
+    return true;
+
+#endif
+
+}
 
 
 /* FVlcMediaPlayer structors
  *****************************************************************************/
 
-FVlcMediaPlayer::FVlcMediaPlayer()
-{ }
 
+FVlcMediaPlayer::FVlcMediaPlayer()
+	: MediaState(EMediaState::Error)
+{
+	MediaUrl = FString();
+	MediaState = EMediaState::Idle;
+
+	vlccontext = new VLCContext();
+	vlchandle = 0;
+	vlcmedia = 0;
+
+#ifdef VLCSDL
+	if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTTHREAD) == -1) {
+      		printf("vlc: cannot initialize SDL\n");
+		return;
+	}
+
+	vlccontext->surf = SDL_CreateRGBSurface(SDL_SWSURFACE, VIDEOWIDTH, VIDEOHEIGHT, 16, 0x001f, 0x07e0, 0xf800, 0);
+	vlccontext->mutex = SDL_CreateMutex();
+
+	// int options = SDL_ANYFORMAT | SDL_HWSURFACE | SDL_DOUBLEBUF;
+	// screen = SDL_SetVideoMode(WIDTH, HEIGHT, 0, options);
+	// if(!screen) {
+	//		printf("cannot set video mode\n");
+	// return EXIT_FAILURE;
+	// }
+
+#else
+
+	vlccontext->pixeldata = malloc(VIDEOWIDTH*VIDEOHEIGHT*4 * 2); // xxx TODO - verify that it is RGBA
+
+#endif
+
+	char const *vlc_argv[] = {
+		"--verbose=2",
+		"--no-video-title-show",
+		"--no-stats",
+		"--no-sub-autodetect-file",
+		"--no-inhibit",
+		"--no-disable-screensaver",
+		"--no-snapshot-preview",
+//		"--intf", "dummy",
+	//	"--vout", "dummy",
+		"--no-audio", /* skip any audio track */
+		"--no-xlib", /* tell VLC to not use Xlib */
+	};
+	int vlc_argc = sizeof(vlc_argv) / sizeof(*vlc_argv);
+	vlchandle = libvlc_new(vlc_argc, vlc_argv);
+	printf("vlc setup done\n");
+}
 
 FVlcMediaPlayer::~FVlcMediaPlayer()
 {
 	Close();
+	MediaState = EMediaState::End;
+	free(vlccontext->pixeldata);
+	vlccontext->pixeldata = 0;
 }
 
 
@@ -21,37 +430,38 @@ FVlcMediaPlayer::~FVlcMediaPlayer()
 
 FTimespan FVlcMediaPlayer::GetDuration() const
 {
-	return FTimespan::Zero();
+        libvlc_time_t duration = libvlc_media_player_get_length((libvlc_media_player_t*)vlcmedia);
+	return FTimespan::FromMilliseconds(duration);
 }
 
 
 TRange<float> FVlcMediaPlayer::GetSupportedRates( EMediaPlaybackDirections Direction, bool Unthinned ) const
 {
-	return TRange<float>(0.0f);
+	return TRange<float>(1.0f);
 }
 
 
 FString FVlcMediaPlayer::GetUrl() const
 {
-	return FString();
+	return MediaUrl;
 }
 
 
 bool FVlcMediaPlayer::SupportsRate( float Rate, bool Unthinned ) const
 {
-	return false;
+	return Rate == 1.0f;
 }
 
 
 bool FVlcMediaPlayer::SupportsScrubbing() const
 {
-	return false;
+	return true;
 }
 
 
 bool FVlcMediaPlayer::SupportsSeeking() const
 {
-	return false;
+	return true;
 }
 
 
@@ -60,8 +470,23 @@ bool FVlcMediaPlayer::SupportsSeeking() const
 
 void FVlcMediaPlayer::Close()
 {
-}
+	if(!vlcmedia) return;
+	MediaUrl = FString();
+	MediaState = EMediaState::Idle;
+	Tracks.Reset();
+	ClosedEvent.Broadcast();
+	libvlc_media_player_stop((libvlc_media_player_t*)vlcmedia);
+	libvlc_media_player_release((libvlc_media_player_t*)vlcmedia);
+	libvlc_release((libvlc_instance_t*)vlchandle);
+	printf("vlc close\n");
+	vlcmedia = 0;
 
+#ifdef VLCSDL
+	SDL_DestroyMutex(vlccontext->mutex);
+	SDL_FreeSurface(vlccontext->surf);
+	SDL_Quit();
+#endif
+}
 
 const IMediaInfo& FVlcMediaPlayer::GetMediaInfo() const 
 {
@@ -71,15 +496,23 @@ const IMediaInfo& FVlcMediaPlayer::GetMediaInfo() const
 
 float FVlcMediaPlayer::GetRate() const
 {
-	return 0.0f;
+	if(!vlcmedia)return 0;
+	return libvlc_media_player_get_rate((libvlc_media_player_t*)vlcmedia);
 }
 
 
 FTimespan FVlcMediaPlayer::GetTime() const 
 {
-	return FTimespan::Zero();
+        if (MediaState != EMediaState::Error)
+        {
+		libvlc_time_t t = libvlc_media_player_get_time((libvlc_media_player_t*)vlcmedia);
+                return FTimespan::FromMilliseconds(t);
+        }
+        else
+        {
+                return FTimespan::Zero();
+        }
 }
-
 
 const TArray<IMediaTrackRef>& FVlcMediaPlayer::GetTracks() const
 {
@@ -89,53 +522,207 @@ const TArray<IMediaTrackRef>& FVlcMediaPlayer::GetTracks() const
 
 bool FVlcMediaPlayer::IsLooping() const 
 {
-	return false;
+	if(!vlcmedia)return false;
+        if (MediaState == EMediaState::Prepared || MediaState == EMediaState::Started ||
+                MediaState == EMediaState::Paused || MediaState == EMediaState::Stopped ||
+                MediaState == EMediaState::PlaybackCompleted)
+        {
+                return false; // TODO todo xxx
+        }
+        else
+        {
+                return false;
+        }
 }
 
 
 bool FVlcMediaPlayer::IsPaused() const
 {
-	return false;
+	if(!vlcmedia)return false;
+	// xxxi TODO todo unsure exactly the right way to do this
+	return !IsPlaying();
+	// return MediaState == EMediaState::Paused;
 }
 
 
 bool FVlcMediaPlayer::IsPlaying() const
 {
+	if(!vlcmedia)return false;
+	if(MediaState != EMediaState::Error) {
+		return libvlc_media_player_is_playing((libvlc_media_player_t*)vlcmedia) ? true : false;
+	}
 	return false;
 }
-
 
 bool FVlcMediaPlayer::IsReady() const
 {
-	return false;
+	if(!vlcmedia)return false;
+        return
+                MediaState == EMediaState::Prepared ||
+                MediaState == EMediaState::Started ||
+                MediaState == EMediaState::Paused ||
+                MediaState == EMediaState::PlaybackCompleted;
 }
-
 
 bool FVlcMediaPlayer::Open( const FString& Url )
 {
-	return false;
+	if(vlcmedia)return false; // xxx could close prev
+
+	if(Url.IsEmpty())
+	{
+		printf("vlc did not get an url\n");
+		return false;
+	}
+	MediaUrl = Url;
+
+	char buffer[1024];
+	const TCHAR* chars = *Url;
+	sprintf(buffer,"%ls",chars);
+
+	libvlc_media_t *m = libvlc_media_new_path((libvlc_instance_t*)vlchandle, buffer);
+	vlcmedia = libvlc_media_player_new_from_media(m);
+	libvlc_media_release(m);
+	libvlc_video_set_callbacks((libvlc_media_player_t*)vlcmedia, vlc_lock, vlc_unlock, vlc_display, vlccontext);
+	libvlc_video_set_format((libvlc_media_player_t*)vlcmedia, "RV32", VIDEOWIDTH, VIDEOHEIGHT, VIDEOWIDTH*4);
+
+	MediaState = EMediaState::Initialized;
+
+	Tracks.Add(MakeShareable(new VideoTrack(*this,Tracks.Num())));
+	Tracks.Add(MakeShareable(new AudioTrack(*this,Tracks.Num())));
+	OpenedEvent.Broadcast(MediaUrl);
+	MediaState = EMediaState::Prepared;
+	Play();
+	return true;
 }
 
+void FVlcMediaPlayer::Play() {
+	if(!vlcmedia)return;
+	libvlc_media_player_play((libvlc_media_player_t*)vlcmedia);
+}
+
+void FVlcMediaPlayer::Stop() {
+	if(!vlcmedia) return;
+	libvlc_media_player_stop((libvlc_media_player_t*)vlcmedia);
+}
 
 bool FVlcMediaPlayer::Open( const TSharedRef<TArray<uint8>>& Buffer, const FString& OriginalUrl )
 {
+	printf("vlcplayer: tried to open the wrong way");
 	return false;
 }
 
 
 bool FVlcMediaPlayer::Seek( const FTimespan& Time )
 {
+    if(!vlcmedia)return false;
+	if(MediaState != EMediaState::Error)
+	{
+		libvlc_time_t t = Time.GetMilliseconds(); // not GetTotal? 
+		libvlc_media_player_set_time((libvlc_media_player_t*)vlcmedia,t);
+		return true;
+	}
 	return false;
 }
 
 
 bool FVlcMediaPlayer::SetLooping( bool Looping )
 {
+	// TODO xxx no reason why we can't support this
+	if(!vlcmedia)return false;
 	return false;
 }
 
-
-bool FVlcMediaPlayer::SetRate( float Rate )
+bool FVlcMediaPlayer::SetRate(float Rate)
 {
-	return false;
+	printf("vlc set the rate to %f\n",Rate);
+	bool success = libvlc_media_player_set_rate((libvlc_media_player_t*)vlcmedia,Rate) == -1 ? false : true;
+	GetRate();
+	if(!success) {
+		printf("vlc failed to set rate\n");
+		return false;
+	}
+
+	// xxx for some reason it auto plays
+
+        switch (MediaState) {
+        case EMediaState::Prepared:
+                if (1.0f == Rate) {
+                        Play();
+                        MediaState = EMediaState::Started;
+                } else if (0.0f == Rate) {
+                        Stop();
+                        MediaState = EMediaState::Paused;
+                }
+                break;
+        case EMediaState::Paused:
+                if (1.0f == Rate) {
+                        Play();
+                        MediaState = EMediaState::Started;
+                }
+                break;
+        case EMediaState::PlaybackCompleted:
+                if (1.0f == Rate) {
+                        Play();
+                        MediaState = EMediaState::Started;
+                }
+                break;
+	default:
+		printf("set rate had an issue with current state\n");
+		return false;
+        }
+	return true;
 }
+
+
+bool FVlcMediaPlayer::Tick( float DeltaTime )
+{
+    if(IsReady() && IsPlaying())
+    {
+        for (IMediaTrackRef& track : Tracks)
+        {
+            MediaTrack &TrackToTick = static_cast<MediaTrack&>(*track);
+            // TrackToTick.TickInRenderThread() ?
+            TrackToTick.Tick(DeltaTime);
+        }
+    }
+    return true;
+}
+
+/*
+typedef TWeakPtr<IMediaTrack, ESPMode::ThreadSafe> IMediaTrackWeakPtr;
+
+void FVlcMediaPlayer::Tick(float DeltaTime)
+{
+        for (IMediaTrackRef track : Tracks)
+        {
+                MediaTrack & TrackToTick = static_cast<MediaTrack&>(*track);
+                if (TrackToTick.TickInRenderThread())
+                {
+                        ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
+                                RenderTickMediaTrack, IMediaTrackWeakPtr, Track, track, float, DeltaT, DeltaTime,
+                                {
+                                        IMediaTrackPtr t = Track.Pin();
+                                        if (t.IsValid())
+                                        {
+                                                StaticCastSharedPtr<MediaTrack>(t)->Tick(DeltaT);
+                                        }
+                                });
+                }
+                else
+                {
+                        TrackToTick.Tick(DeltaTime);
+                }
+        }
+}
+
+TStatId FVlcMediaPlayer::GetStatId() const
+{
+        RETURN_QUICK_DECLARE_CYCLE_STAT(FVlcMediaPlayer, STATGROUP_Tickables);
+}
+
+bool FVlcMediaPlayer::IsTickable() const
+{
+        return true;
+}
+*/
+

--- a/Source/VlcMedia/Private/Player/VlcMediaPlayer.h
+++ b/Source/VlcMedia/Private/Player/VlcMediaPlayer.h
@@ -73,7 +73,8 @@ public:
         //virtual TStatId GetStatId() const override;
         //virtual bool IsTickable() const override;
 
-	bool GetVideoLastFrameData(void* &SampleData,int64 &SampleCount);
+	bool LockGetVideoLastFrameData(void* &SampleData,int64 &SampleCount);
+	bool Unlock();
 private:
 
         class MediaTrack;

--- a/Source/VlcMedia/Private/Player/VlcMediaPlayer.h
+++ b/Source/VlcMedia/Private/Player/VlcMediaPlayer.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include "ModuleManager.h"
+#include "Media.h"
+#include "Tickable.h"
 
 /**
  * Implements a media player using the Video LAN Codec (VLC) framework.
@@ -9,6 +12,8 @@
 class FVlcMediaPlayer
 	: public IMediaInfo
 	, public IMediaPlayer
+	, public FTickerObjectBase
+//	, public FTickableGameObject
 {
 public:
 
@@ -30,6 +35,8 @@ public:
 	virtual bool SupportsSeeking() const override;
 
 public:
+	void Play();
+	void Stop();
 
 	// IMediaPlayer interface
 
@@ -60,16 +67,44 @@ public:
 		return OpenedEvent;
 	}
 
+        // FTickableObjectRenderThread
+
+        virtual bool Tick(float DeltaTime) override;
+        //virtual TStatId GetStatId() const override;
+        //virtual bool IsTickable() const override;
+
+	bool GetVideoLastFrameData(void* &SampleData,int64 &SampleCount);
 private:
 
-	/** The available media tracks. */
-	TArray<IMediaTrackRef> Tracks;
+        class MediaTrack;
+        class VideoTrack;
+        class AudioTrack;
 
-private:
+
+        // Local state to track where the Java side media player is at.
+        enum class EMediaState
+        {
+                Idle, Initialized, Preparing, Prepared, Started,
+                Paused, Stopped, PlaybackCompleted, End, Error
+        };
+
+        // Our understanding of the state of the Java media player.
+        EMediaState MediaState;
 
 	/** Holds an event delegate that is invoked when media has been closed. */
 	FOnMediaClosed ClosedEvent;
 
 	/** Holds an event delegate that is invoked when media has been opened. */
 	FOnMediaOpened OpenedEvent;
+
+	// Currently opened media.
+	FString MediaUrl;
+
+	// The pseudo-tracks in the media.
+	TArray<IMediaTrackRef> Tracks;
+
+	// vlc context
+	struct VLCContext* vlccontext;
+	void *vlchandle;
+	void *vlcmedia;
 };

--- a/Source/VlcMedia/Private/VlcMediaModule.cpp
+++ b/Source/VlcMedia/Private/VlcMediaModule.cpp
@@ -37,7 +37,7 @@ public:
 
 		if (MediaModule == nullptr)
 		{
-			UE_LOG(LogVlcMedia, Log, TEXT("Failed to load Media module"));
+			UE_LOG(LogVlcMedia, Log, TEXT("VLC: Failed to load Media module"));
 
 			return;
 		}
@@ -47,7 +47,7 @@ public:
 			UE_LOG(LogVlcMedia, Log, TEXT("Failed to load required Windows Media Foundation libraries"));
 
 			return;
-		}*/
+		}
 
 		// initialize libvlc
 
@@ -57,9 +57,9 @@ public:
 
 			return;
 		}
-
+*/
 		// initialize supported media formats
-/*		SupportedFileTypes.Add(TEXT("3g2"), LOCTEXT("Format3g2", "3G2 Multimedia Stream"));
+		SupportedFileTypes.Add(TEXT("3g2"), LOCTEXT("Format3g2", "3G2 Multimedia Stream"));
 		SupportedFileTypes.Add(TEXT("3gp"), LOCTEXT("Format3gp", "3GP Video Stream"));
 		SupportedFileTypes.Add(TEXT("3gp2"), LOCTEXT("Format3gp2", "3GPP2 Multimedia File"));
 		SupportedFileTypes.Add(TEXT("3gpp"), LOCTEXT("Format3gpp", "3GPP Multimedia File"));
@@ -72,7 +72,7 @@ public:
 		SupportedFileTypes.Add(TEXT("mp4"), LOCTEXT("FormatMp4", "MPEG-4 Movie"));
 		SupportedFileTypes.Add(TEXT("sami"), LOCTEXT("FormatSami", "Synchronized Accessible Media Interchange (SAMI) File"));
 		SupportedFileTypes.Add(TEXT("smi"), LOCTEXT("FormatSmi", "Synchronized Multimedia Integration (SMIL) File"));
-		SupportedFileTypes.Add(TEXT("wmv"), LOCTEXT("FormatWmv", "Windows Media Video"));*/
+		SupportedFileTypes.Add(TEXT("wmv"), LOCTEXT("FormatWmv", "Windows Media Video"));
 
 		// register factory
 		MediaModule->RegisterPlayerFactory(*this);
@@ -114,7 +114,7 @@ public:
 
 		return nullptr;
 	}
-
+/*
 	virtual const FMediaFileTypes& GetSupportedFileTypes() const override
 	{
 		return SupportedFileTypes;
@@ -124,6 +124,13 @@ public:
 	{
 		return SupportedFileTypes.Contains(FPaths::GetExtension(Url));
 	}
+*/
+
+        virtual const FMediaFormats& GetSupportedFormats() const override
+        {
+                return SupportedFileTypes;
+        }
+
 
 protected:
 
@@ -143,7 +150,7 @@ private:
 	bool Initialized;
 
 	/** The collection of supported media file types. */
-	FMediaFileTypes SupportedFileTypes;
+	FMediaFormats SupportedFileTypes;
 };
 
 

--- a/Source/VlcMedia/VlcMedia.Build.cs
+++ b/Source/VlcMedia/VlcMedia.Build.cs
@@ -1,4 +1,5 @@
 // Copyright 2015 Headcrash Industries LLC. All Rights Reserved.
+// Modified by @anselm
 
 namespace UnrealBuildTool.Rules
 {
@@ -6,36 +7,41 @@ namespace UnrealBuildTool.Rules
 	{
 		public VlcMedia(TargetInfo Target)
 		{
-            DynamicallyLoadedModuleNames.AddRange(
-                new string[] {
-                    "Media",
+			DynamicallyLoadedModuleNames.AddRange(
+				new string[] {
+					"Media", "Settings",
 				}
-            );
+			);
 
 			PrivateDependencyModuleNames.AddRange(
 				new string[] {
-					"Core",
-                    "RenderCore",
+					"Core","CoreUObject","Engine", "RenderCore",
 				}
 			);
 
 			PrivateIncludePathModuleNames.AddRange(
 				new string[] {
-                    "Media",
+					"Media", "Settings",
 				}
 			);
 
 			PrivateIncludePaths.AddRange(
 				new string[] {
-					"VlcMedia/Private",
-                    "VlcMedia/Private/Player",
+					"VlcMedia/Private", "VlcMedia/Private/Player",
 				}
 			);
 
-            if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
-            {
-                //PublicDelayLoadDLLs.Add("shlwapi.dll");
-            }
+
+			if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
+			{
+				//PublicDelayLoadDLLs.Add("shlwapi.dll");
+			}
+
+			if (Target.Platform == UnrealTargetPlatform.Linux)
+			{
+				AddThirdPartyPrivateStaticDependencies(Target, "SDL2");
+				PublicAdditionalLibraries.Add("/usr/lib/libvlc.so");
+			}
 		}
 	}
 }

--- a/VlcMedia.uplugin
+++ b/VlcMedia.uplugin
@@ -18,7 +18,7 @@
 			"Name" : "VlcMedia",
 			"Type" : "RuntimeNoCommandlet",
 			"LoadingPhase" : "PreLoadingScreen",
-			"WhitelistPlatforms" : [ "Win32", "Win64" ]
+			"WhitelistPlatforms" : [ "Win32", "Win64", "Linux" ]
 		}
 	],
 


### PR DESCRIPTION
...e 4.7

we needed this on short notice for a demo so i hacked it together very quickly and it may not be 100% but should help
make sure to apt-get install vlc and libvlc-dev; the plugin is looking for the libvlc.so at a hardcoded location
throw this entire thing into /UnrealEngine/Engine/Plugins/Media/VlcMedia and cd UnrealEngine and make UE4Editor and have fun
there is no audio support in this version
this was cobbled together by looking at the other plugins and playing a bit with some standalone libvlc examples
initially sdl was used for surfaces but it proved to be unstable (probably not doing the mutex locks correctly) so that is disabled
right now it directly allocates a ram buffer and asks libvlc to produce a chroma with RGBA 32 bit depth (they call it RV32)
there are several small bugs that probably need work such as:
 - i notice that the media player controls on the main panel don't always start/stop/pause properly; not 100% sure why
 - looping isn't turned on
 - audio is not written yet (and it is disabled in the parameters i pass to libvlc)
 - haven't tested multiple simultaneous streams
 - not using any mutexes to lock video buffers so imagine there may be some tearing
 - only supports a single video track and single audio track; some of the other media players for other platforms are fancier
 - disabled subtitles and things like that by passing appropriate parameters to libvlc