### PR TITLE
Fixed possible null pointer exception

### DIFF
--- a/Source/VlcMedia/Private/Player/VlcMediaPlayer.cpp
+++ b/Source/VlcMedia/Private/Player/VlcMediaPlayer.cpp
@@ -325,6 +325,8 @@ void FVlcMediaPlayer::InitializeTracks()
 	{
 		return;
 	}
+	
+	FVlc::MediaPlayerStop(Player);
 
 	FLibvlcMedia* Media = FVlc::MediaPlayerGetMedia(Player);
 
@@ -390,7 +392,6 @@ bool FVlcMediaPlayer::HandleTicker(float DeltaTime)
 	if (Tracks.Num() == 0)
 	{
 		InitializeTracks();
-		FVlc::MediaPlayerStop(Player);
 	}
 	else
 	{


### PR DESCRIPTION
Fixed possible null pointer exception when Player with nullptr passed to FVlc::MediaPlayerStop(Player);