### PR TITLE
Solve freeze on shipping

### DIFF
--- a/Source/VlcMedia/Private/Player/VlcMediaCallbacks.cpp
+++ b/Source/VlcMedia/Private/Player/VlcMediaCallbacks.cpp
@@ -11,6 +11,7 @@
 #include "Vlc.h"
 #include "VlcMediaAudioSample.h"
 #include "VlcMediaTextureSample.h"
+#include "VlcMediaSamples.h"
 
 
 /* FVlcMediaOutput structors
@@ -24,7 +25,7 @@ FVlcMediaCallbacks::FVlcMediaCallbacks()
 	, AudioSampleSize(0)
 	, CurrentTime(FTimespan::Zero())
 	, Player(nullptr)
-	, Samples(new FMediaSamples)
+	, Samples(new FVlcMediaSamples)
 	, VideoBufferDim(FIntPoint::ZeroValue)
 	, VideoBufferStride(0)
 	, VideoFrameDuration(FTimespan::Zero())

--- a/Source/VlcMedia/Private/Player/VlcMediaCallbacks.h
+++ b/Source/VlcMedia/Private/Player/VlcMediaCallbacks.h
@@ -15,6 +15,8 @@ class IMediaOverlaySink;
 class IMediaSamples;
 class IMediaTextureSink;
 
+class FVlcMediaSamples;
+
 struct FLibvlcMediaPlayer;
 
 
@@ -122,7 +124,7 @@ private:
 	FLibvlcMediaPlayer* Player;
 
 	/** The output media samples. */
-	FMediaSamples* Samples;
+	FVlcMediaSamples* Samples;
 
 	/** Current video buffer dimensions (accessed by VLC thread only; may be larger than VideoOutputDim). */
 	FIntPoint VideoBufferDim;

--- a/Source/VlcMedia/Private/Player/VlcMediaSamples.cpp
+++ b/Source/VlcMedia/Private/Player/VlcMediaSamples.cpp
@@ -1,0 +1,154 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "VlcMediaSamples.h"
+
+#include "IMediaAudioSample.h"
+#include "IMediaBinarySample.h"
+#include "IMediaOverlaySample.h"
+#include "IMediaTextureSample.h"
+
+/* IMediaSamples interface
+*****************************************************************************/
+
+bool FVlcMediaSamples::FetchAudio(TRange<FTimespan> TimeRange, TSharedPtr<IMediaAudioSample, ESPMode::ThreadSafe>& OutSample)
+{
+	TSharedPtr<IMediaAudioSample, ESPMode::ThreadSafe> Sample;
+
+	if (!AudioSampleQueue.Peek(Sample))
+	{
+		return false;
+	}
+
+	const FTimespan SampleTime = Sample->GetTime();
+
+	if (!TimeRange.Overlaps(TRange<FTimespan>(SampleTime, SampleTime + Sample->GetDuration())))
+	{
+		return false;
+	}
+
+	if (!AudioSampleQueue.Dequeue(Sample))
+	{
+		return false;
+	}
+
+	OutSample = Sample;
+
+	return true;
+}
+
+
+bool FVlcMediaSamples::FetchCaption(TRange<FTimespan> TimeRange, TSharedPtr<IMediaOverlaySample, ESPMode::ThreadSafe>& OutSample)
+{
+	TSharedPtr<IMediaOverlaySample, ESPMode::ThreadSafe> Sample;
+
+	if (!CaptionSampleQueue.Peek(Sample))
+	{
+		return false;
+	}
+
+	const FTimespan SampleTime = Sample->GetTime();
+
+	if (!TimeRange.Overlaps(TRange<FTimespan>(SampleTime, SampleTime + Sample->GetDuration())))
+	{
+		return false;
+	}
+
+	if (!CaptionSampleQueue.Dequeue(Sample))
+	{
+		return false;
+	}
+
+	OutSample = Sample;
+
+	return true;
+}
+
+
+bool FVlcMediaSamples::FetchMetadata(TRange<FTimespan> TimeRange, TSharedPtr<IMediaBinarySample, ESPMode::ThreadSafe>& OutSample)
+{
+	TSharedPtr<IMediaBinarySample, ESPMode::ThreadSafe> Sample;
+
+	if (!MetadataSampleQueue.Peek(Sample))
+	{
+		return false;
+	}
+
+	const FTimespan SampleTime = Sample->GetTime();
+
+	if (!TimeRange.Overlaps(TRange<FTimespan>(SampleTime, SampleTime + Sample->GetDuration())))
+	{
+		return false;
+	}
+
+	if (!MetadataSampleQueue.Dequeue(Sample))
+	{
+		return false;
+	}
+
+	OutSample = Sample;
+
+	return true;
+}
+
+
+bool FVlcMediaSamples::FetchSubtitle(TRange<FTimespan> TimeRange, TSharedPtr<IMediaOverlaySample, ESPMode::ThreadSafe>& OutSample)
+{
+	TSharedPtr<IMediaOverlaySample, ESPMode::ThreadSafe> Sample;
+
+	if (!SubtitleSampleQueue.Peek(Sample))
+	{
+		return false;
+	}
+
+	const FTimespan SampleTime = Sample->GetTime();
+
+	if (!TimeRange.Overlaps(TRange<FTimespan>(SampleTime, SampleTime + Sample->GetDuration())))
+	{
+		return false;
+	}
+
+	if (!SubtitleSampleQueue.Dequeue(Sample))
+	{
+		return false;
+	}
+	OutSample = Sample;
+
+	return true;
+}
+
+
+bool FVlcMediaSamples::FetchVideo(TRange<FTimespan> TimeRange, TSharedPtr<IMediaTextureSample, ESPMode::ThreadSafe>& OutSample)
+{
+	TSharedPtr<IMediaTextureSample, ESPMode::ThreadSafe> Sample;
+
+	if (!VideoSampleQueue.Peek(Sample))
+	{
+		return false;
+	}
+
+	const FTimespan SampleTime = Sample->GetTime();
+
+	if (!TimeRange.Overlaps(TRange<FTimespan>(SampleTime, SampleTime + Sample->GetDuration())))
+	{
+		return false;
+	}
+
+	if (!VideoSampleQueue.Dequeue(Sample))
+	{
+		return false;
+	}
+
+	OutSample = Sample;
+
+	return true;
+}
+
+
+void FVlcMediaSamples::FlushSamples()
+{
+	AudioSampleQueue.RequestFlush();
+	MetadataSampleQueue.RequestFlush();
+	CaptionSampleQueue.RequestFlush();
+	VideoSampleQueue.RequestFlush();
+}
+

--- a/Source/VlcMedia/Private/Player/VlcMediaSamples.h
+++ b/Source/VlcMedia/Private/Player/VlcMediaSamples.h
@@ -1,0 +1,161 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CoreTypes.h"
+#include "IMediaSamples.h"
+#include "Templates/SharedPointer.h"
+
+#include "MediaSampleQueue.h"
+
+class IMediaAudioSample;
+class IMediaBinarySample;
+class IMediaOverlaySample;
+class IMediaTextureSample;
+
+/**
+ * 
+ */
+class FVlcMediaSamples : public IMediaSamples
+{
+public:
+
+	/**
+	* Add the given audio sample to the cache.
+	*
+	* @param Sample The sample to add.
+	* @see AddCaption, AddMetadata, AddSubtitle, AddVideo, NumAudio
+	*/
+	void AddAudio(const TSharedRef<IMediaAudioSample, ESPMode::ThreadSafe>& Sample)
+	{
+		AudioSampleQueue.Enqueue(Sample);
+	}
+
+	/**
+	* Add the given caption sample to the cache.
+	*
+	* @param Sample The sample to add.
+	* @see AddAudio, AddMetadata, AddSubtitle, AddVideo, NumCaption
+	*/
+	void AddCaption(const TSharedRef<IMediaOverlaySample, ESPMode::ThreadSafe>& Sample)
+	{
+		CaptionSampleQueue.Enqueue(Sample);
+	}
+
+	/**
+	* Add the given audio sample to the cache.
+	*
+	* @param Sample The sample to add.
+	* @see AddAudio, AddCaption, AddSubtitle, AddVideo, NumMetadata
+	*/
+	void AddMetadata(const TSharedRef<IMediaBinarySample, ESPMode::ThreadSafe>& Sample)
+	{
+		MetadataSampleQueue.Enqueue(Sample);
+	}
+
+	/**
+	* Add the given subtitle sample to the cache.
+	*
+	* @param Sample The sample to add.
+	* @see AddAudio, AddCaption, AddMetadata, AddVideo, NumSubtitle
+	*/
+	void AddSubtitle(const TSharedRef<IMediaOverlaySample, ESPMode::ThreadSafe>& Sample)
+	{
+		SubtitleSampleQueue.Enqueue(Sample);
+	}
+
+	/**
+	* Add the given audio sample to the cache.
+	*
+	* @param Sample The sample to add.
+	* @see AddAudio, AddCaption, AddMetadata, AddSubtitle, NumVideo
+	*/
+	void AddVideo(const TSharedRef<IMediaTextureSample, ESPMode::ThreadSafe>& Sample)
+	{
+		VideoSampleQueue.Enqueue(Sample);
+	}
+
+	/**
+	* Get the number of queued audio samples.
+	*
+	* @return Number of samples.
+	* @see AddAudio, NumCaption, NumMetadata, NumSubtitle, NumVideo
+	*/
+	int32 NumAudio() const
+	{
+		return AudioSampleQueue.Num();
+	}
+
+	/**
+	* Get the number of queued caption samples.
+	*
+	* @return Number of samples.
+	* @see AddCaption, NumAudio, NumMetadata, NumSubtitle, NumVideo
+	*/
+	int32 NumCaption() const
+	{
+		return CaptionSampleQueue.Num();
+	}
+
+	/**
+	* Get the number of queued metadata samples.
+	*
+	* @return Number of samples.
+	* @see AddMetadata, NumAudio, NumCaption, NumSubtitle, NumVideo
+	*/
+	int32 NumMetadataSamples() const
+	{
+		return MetadataSampleQueue.Num();
+	}
+
+	/**
+	* Get the number of queued subtitle samples.
+	*
+	* @return Number of samples.
+	* @see AddSubtitle, NumAudio, NumCaption, NumMetadata, NumVideo
+	*/
+	int32 NumSubtitleSamples() const
+	{
+		return SubtitleSampleQueue.Num();
+	}
+
+	/**
+	* Get the number of queued video samples.
+	*
+	* @return Number of samples.
+	* @see AddVideo, NumAudio, NumCaption, NumMetadata, NumSubtitle
+	*/
+	int32 NumVideoSamples() const
+	{
+		return VideoSampleQueue.Num();
+	}
+
+public:
+
+	//~ IMediaSamples interface
+
+	virtual bool FetchAudio(TRange<FTimespan> TimeRange, TSharedPtr<IMediaAudioSample, ESPMode::ThreadSafe>& OutSample) override;
+	virtual bool FetchCaption(TRange<FTimespan> TimeRange, TSharedPtr<IMediaOverlaySample, ESPMode::ThreadSafe>& OutSample) override;
+	virtual bool FetchMetadata(TRange<FTimespan> TimeRange, TSharedPtr<IMediaBinarySample, ESPMode::ThreadSafe>& OutSample) override;
+	virtual bool FetchSubtitle(TRange<FTimespan> TimeRange, TSharedPtr<IMediaOverlaySample, ESPMode::ThreadSafe>& OutSample) override;
+	virtual bool FetchVideo(TRange<FTimespan> TimeRange, TSharedPtr<IMediaTextureSample, ESPMode::ThreadSafe>& OutSample) override;
+	virtual void FlushSamples() override;
+
+private:
+
+	/** Audio sample queue. */
+	TMediaSampleQueue<IMediaAudioSample> AudioSampleQueue;
+
+	/** Caption sample queue. */
+	TMediaSampleQueue<IMediaOverlaySample> CaptionSampleQueue;
+
+	/** Metadata sample queue. */
+	TMediaSampleQueue<IMediaBinarySample> MetadataSampleQueue;
+
+	/** Subtitle sample queue. */
+	TMediaSampleQueue<IMediaOverlaySample> SubtitleSampleQueue;
+
+	/** Video sample queue. */
+	TMediaSampleQueue<IMediaTextureSample> VideoSampleQueue;
+};


### PR DESCRIPTION
Default FMediaSamples blocks cause check(VideoSampleQueue.Pop()) in FetchVideo() will not compile on shipping and lead to an infinite loop